### PR TITLE
Deserialization refactor

### DIFF
--- a/Examples/ClientApp/ViewModel/ChildElementViewModel.cs
+++ b/Examples/ClientApp/ViewModel/ChildElementViewModel.cs
@@ -1,9 +1,4 @@
 ﻿using SharedInterfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ClientApp.ViewModel
 {
@@ -13,7 +8,7 @@ namespace ClientApp.ViewModel
         {
             ChildElement = childElement;
         }
-        
+
         public IChildElement ChildElement { get; }
 
     }

--- a/Examples/ClientApp/ViewModel/MainWindowViewModel.cs
+++ b/Examples/ClientApp/ViewModel/MainWindowViewModel.cs
@@ -7,6 +7,7 @@ using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace ClientApp.ViewModel
 {
@@ -83,15 +84,18 @@ namespace ClientApp.ViewModel
             while (!_isDisposed && _remoteClient is null)
                 try
                 {
-                    _remoteClient = new RemoteClient(address);
+                    _remoteClient = new RemoteClient(address, Application.Current.Dispatcher);
                 }
                 catch { }
             if (_remoteClient is null)
                 return;
             _remoteClient.Disconnected += RemoteClient_Disconnected;
             var root = _remoteClient.GetRootObject<IRootElement>();
-            RootElement = new RootElementViewModel(root);
-            IsConnecting = false;
+            Application.Current.Dispatcher.BeginInvoke((Action)(() =>
+            {
+                RootElement = new RootElementViewModel(root);
+                IsConnecting = false;
+            }));
         }
 
         private void RemoteClient_Disconnected(object sender, EventArgs e)

--- a/Examples/ClientApp/ViewModel/MainWindowViewModel.cs
+++ b/Examples/ClientApp/ViewModel/MainWindowViewModel.cs
@@ -84,7 +84,7 @@ namespace ClientApp.ViewModel
             while (!_isDisposed && _remoteClient is null)
                 try
                 {
-                    _remoteClient = new RemoteClient(address, Application.Current.Dispatcher);
+                    _remoteClient = new RemoteClient(address);
                 }
                 catch { }
             if (_remoteClient is null)

--- a/Examples/ServerApp/Model/RootElement.cs
+++ b/Examples/ServerApp/Model/RootElement.cs
@@ -25,13 +25,14 @@ namespace ServerApp.Model
 
         public event EventHandler<ChildEventArgs> ChildRemoved;
 
-        public void AddChild()
+        public IChildElement AddChild()
         {
             var newChild = new ChildElement();
             newChild.Value = 75;
             lock (_sync)
                 _childElements.Add(newChild);
             ChildAdded?.Invoke(this, new ChildEventArgs(newChild));
+            return newChild;
         }
 
         public IChildElement[] GetChildrens()

--- a/Examples/SharedInterfaces/IRootElement.cs
+++ b/Examples/SharedInterfaces/IRootElement.cs
@@ -5,7 +5,7 @@ namespace SharedInterfaces
 {
     public interface IRootElement
     {
-        void AddChild();
+        IChildElement AddChild();
         bool RemoveChild(IChildElement childElement);
         IChildElement[] GetChildrens();
         string Name { get; set; }

--- a/Tests/Tests.ClientLibrary/Level1/Level2/Level3/MockMember.cs
+++ b/Tests/Tests.ClientLibrary/Level1/Level2/Level3/MockMember.cs
@@ -31,9 +31,5 @@ namespace Tests.ClientLibrary.Level1.Level2.Level3
                 EventRemove(_propertyChanged);
             }
         }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/Tests.ClientLibrary/Level1/Level2/Level3/MockRoot.cs
+++ b/Tests/Tests.ClientLibrary/Level1/Level2/Level3/MockRoot.cs
@@ -32,9 +32,5 @@ namespace Tests.ClientLibrary.Level1.Level2.Level3
             return Query<IMockMember>(parameters: new object[] { index });
         }
 
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
-
     }
 }

--- a/Tests/Tests.ClientLibrary/Level1/Level2/MockMember.cs
+++ b/Tests/Tests.ClientLibrary/Level1/Level2/MockMember.cs
@@ -31,9 +31,5 @@ namespace Tests.ClientLibrary.Level1.Level2
                 EventRemove(_propertyChanged);
             }
         }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/Tests.ClientLibrary/Level1/Level2/MockRoot.cs
+++ b/Tests/Tests.ClientLibrary/Level1/Level2/MockRoot.cs
@@ -31,9 +31,5 @@ namespace Tests.ClientLibrary.Level1.Level2
         {
             return Query<IMockMember>(parameters: new object[] { index });
         }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/Tests.ClientLibrary/Level1/MockMember.cs
+++ b/Tests/Tests.ClientLibrary/Level1/MockMember.cs
@@ -32,9 +32,5 @@ namespace Tests.ClientLibrary.Level1
                 EventRemove(_propertyChanged);
             }
         }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/Tests.ClientLibrary/Level1/MockRoot.cs
+++ b/Tests/Tests.ClientLibrary/Level1/MockRoot.cs
@@ -5,7 +5,6 @@ using Tests.CommonLibrary;
 
 namespace Tests.ClientLibrary.Level1
 {
-    [DtoType(typeof(IMockRoot))]
     public class MockRoot : ProxyObjectBase, IMockRoot
     {
 #pragma warning disable CS0649
@@ -31,10 +30,6 @@ namespace Tests.ClientLibrary.Level1
         public IMockMember GetMockMember(int index)
         {
             return Query<IMockMember>(parameters: new object[] { index });
-        }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
         }
     }
 }

--- a/Tests/Tests.ClientLibrary/MockMember.cs
+++ b/Tests/Tests.ClientLibrary/MockMember.cs
@@ -31,9 +31,5 @@ namespace Tests.ClientLibrary
                 EventRemove(_propertyChanged);
             }
         }
-
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/Tests.ClientLibrary/MockRoot.cs
+++ b/Tests/Tests.ClientLibrary/MockRoot.cs
@@ -32,8 +32,5 @@ namespace Tests.ClientLibrary
             return Query<IMockMember>(parameters: new object[] { index });
         }
 
-        protected override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/jNet.RPC.IntegrationTests/Communication/ResolvingProxyTypeTests.cs
+++ b/Tests/jNet.RPC.IntegrationTests/Communication/ResolvingProxyTypeTests.cs
@@ -85,34 +85,29 @@ namespace jNet.RPC.IntegrationTests.Communication
             var server = new ServerHost(1036, root);
             var client = new RemoteClient("127.0.0.1:1036");
             client.AddProxyAssembly(typeof(Tests.ClientLibrary.MockRoot).Assembly);
-
+            var clientRoot = client.GetRootObject<IMockRoot>();
             // act
-            var rootProxy = client.GetRootObject<IMockRoot>();
-            var reference = GetMockMember(rootProxy);
+            var reference = GetMockMember(clientRoot);
+            clientRoot.SimpleMethod(); // call something to flush reference in client
 
             // assert - proxy should exists
-            Assert.IsFalse(IsReferenceNull(reference));
+            Assert.IsTrue(reference.IsAlive);
 
             // act
             GC.Collect();
             GC.Collect();
 
             // assert - after GC run proxy should be destroyed
-            Assert.IsTrue(IsReferenceNull(reference));
+            Assert.IsFalse(reference.IsAlive);
 
             // cleanup
             client.Dispose();
             server.Dispose();
         }
-
+        
         private WeakReference GetMockMember(IMockRoot proxy)
         {
             return new WeakReference(proxy.GetMockMember(0));
-        }
-
-        private static bool IsReferenceNull(WeakReference reference)
-        {
-            return reference.Target is null;
         }
     }
 }

--- a/Tests/jNet.RPC.UnitTests/MockModel/MockProxy.cs
+++ b/Tests/jNet.RPC.UnitTests/MockModel/MockProxy.cs
@@ -11,9 +11,5 @@ namespace jNet.RPCTests.MockModel
         private string _value;
 #pragma warning restore
         public string Value { get => _value; set => Set(value); }
-
-        protected internal override void OnEventNotification(SocketMessage message)
-        {
-        }
     }
 }

--- a/Tests/jNet.RPC.UnitTests/MockModel/MockProxyObject.cs
+++ b/Tests/jNet.RPC.UnitTests/MockModel/MockProxyObject.cs
@@ -9,10 +9,5 @@ namespace jNet.RPC.UnitTests.MockModel
         private string _value;
 #pragma warning restore
         public string Value { get => _value; set => Set(value); }
-
-        protected internal override void OnEventNotification(SocketMessage message)
-        {
-
-        }
     }
 }

--- a/jNet.RPC.slnLaunch.user
+++ b/jNet.RPC.slnLaunch.user
@@ -1,0 +1,15 @@
+[
+  {
+    "Name": "Server + Client",
+    "Projects": [
+      {
+        "Path": "Examples\\ServerApp\\ServerApp.csproj",
+        "Action": "Start"
+      },
+      {
+        "Path": "Examples\\ClientApp\\ClientApp.csproj",
+        "Action": "Start"
+      }
+    ]
+  }
+]

--- a/jNet.RPC/Client/ClientSession.cs
+++ b/jNet.RPC/Client/ClientSession.cs
@@ -120,7 +120,7 @@ namespace jNet.RPC.Client
                             else
                             {
                                 EventArgs eventArgs = deserialized as EventArgs;
-                                _notificationExecutor.Queue(() => notifyObject.OnNotificationMessage(message.MemberName, eventArgs));
+                                _notificationExecutor.Queue(() => notifyObject.OnEventNotification(message.MemberName, eventArgs));
                             }
                             break;
 

--- a/jNet.RPC/Client/ClientSession.cs
+++ b/jNet.RPC/Client/ClientSession.cs
@@ -119,7 +119,7 @@ namespace jNet.RPC.Client
                                 Logger.Debug("Proxy to notify not found for message: {0}, notification was {1}", message, deserialized);
                             else
                             {
-                                EventArgs eventArgs = deserialized as EventArgs;
+                                var eventArgs = deserialized as EventArgs;
                                 _notificationExecutor.Queue(() => notifyObject.OnEventNotification(message.MemberName, eventArgs));
                             }
                             break;

--- a/jNet.RPC/Client/MessageRequest.cs
+++ b/jNet.RPC/Client/MessageRequest.cs
@@ -6,24 +6,28 @@ namespace jNet.RPC.Client
     internal class MessageRequest: IDisposable
     {
         private readonly ManualResetEvent _mutex = new ManualResetEvent(false);
-        private SocketMessage _result;
+        private object _result;
+        private SocketMessage.SocketMessageType? _socketMessageType;
 
         public void Dispose()
         {
             _mutex.Dispose();
         }
 
-        public void SetResult(SocketMessage message)
+        public void SetResult(SocketMessage.SocketMessageType socketMessageType, object result)
         {
-            _result = message;
+            _socketMessageType = socketMessageType;
+            _result = result;
             _mutex.Set();
         }
 
-        public SocketMessage WaitForResult(CancellationToken token)
+        public object WaitForResult(CancellationToken token)
         {
             WaitHandle.WaitAny(new[] { token.WaitHandle, _mutex });
             return _result;
         }
+
+        public SocketMessage.SocketMessageType? MessageType => _socketMessageType;
 
     }
 }

--- a/jNet.RPC/Client/ProxyBuilder.cs
+++ b/jNet.RPC/Client/ProxyBuilder.cs
@@ -53,6 +53,7 @@ namespace jNet.RPC.Client
             var ilGen = onEventNotificationMethod.GetILGenerator();
             var caseLabels = events.Select(l => ilGen.DefineLabel()).ToArray();
             var retLabel = ilGen.DefineLabel();
+            var baseMethodLabel = ilGen.DefineLabel();
 
             for (int i = 0; i < events.Length; i++)
             {
@@ -62,7 +63,7 @@ namespace jNet.RPC.Client
                 ilGen.Emit(OpCodes.Brtrue_S, caseLabels[i]);
             }
 
-            ilGen.Emit(OpCodes.Br, retLabel); // jump to return if no event matches
+            ilGen.Emit(OpCodes.Br, baseMethodLabel); // jump to return if no event matches
 
             for (int i = 0; i < events.Length; i++)
             {
@@ -82,6 +83,12 @@ namespace jNet.RPC.Client
                 ilGen.Emit(OpCodes.Callvirt, eventHandlerMethod); // call the event field with sender and args parameters from evaluation stack
                 ilGen.Emit(OpCodes.Br, retLabel); // jump to return after handling the event
             }
+
+            ilGen.MarkLabel(baseMethodLabel);
+            ilGen.Emit(OpCodes.Ldarg_0); // load 'this'
+            ilGen.Emit(OpCodes.Ldarg_1); // load event name
+            ilGen.Emit(OpCodes.Ldarg_2); // load EventArgs
+            ilGen.Emit(OpCodes.Call, baseMethod); // call base method
 
             ilGen.MarkLabel(retLabel);
             ilGen.Emit(OpCodes.Ret);

--- a/jNet.RPC/Client/ProxyObjectBase.cs
+++ b/jNet.RPC/Client/ProxyObjectBase.cs
@@ -110,7 +110,6 @@ namespace jNet.RPC.Client
         /// <param name="eventArgs">Event args, deserialized according to type info. Cast it to specific derived type/</param>
         protected internal virtual void OnEventNotification(string eventName, EventArgs eventArgs)
         {
-            Logger.Trace("On NotificationMessage {0}", eventName);
             if (eventName == nameof(INotifyPropertyChanged.PropertyChanged))
             {
                 var eav = eventArgs as PropertyChangedWithValueEventArgs;

--- a/jNet.RPC/Client/ProxyObjectBase.cs
+++ b/jNet.RPC/Client/ProxyObjectBase.cs
@@ -92,8 +92,6 @@ namespace jNet.RPC.Client
             }
         }
 
-        protected internal abstract void OnEventNotification(string eventName, EventArgs eventArgs);
-
         protected void NotifyPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -105,12 +103,12 @@ namespace jNet.RPC.Client
             _client = (RemoteClient)context.Context;
         }
 
-        protected internal T DeserializeEventArgs<T>(SocketMessage message) where T: EventArgs
-        {
-            return _client?.Deserialize(message) as T;
-        }
-
-        internal void OnNotificationMessage(string eventName, EventArgs eventArgs)
+        /// <summary>
+        /// This method provides default PropertyChanged event handling. Override it to support more events.
+        /// </summary>
+        /// <param name="eventName">Event name. Event with this name have to be defined in interface.</param>
+        /// <param name="eventArgs">Event args, deserialized according to type info. Cast it to specific derived type/</param>
+        protected internal virtual void OnEventNotification(string eventName, EventArgs eventArgs)
         {
             Logger.Trace("On NotificationMessage {0}", eventName);
             if (eventName == nameof(INotifyPropertyChanged.PropertyChanged))
@@ -138,7 +136,6 @@ namespace jNet.RPC.Client
                 }
                 NotifyPropertyChanged(eav.PropertyName);
             }
-            else OnEventNotification(eventName, eventArgs);
         }
 
         protected FieldInfo GetField(Type t, string fieldName)

--- a/jNet.RPC/Client/ProxyObjectBase.cs
+++ b/jNet.RPC/Client/ProxyObjectBase.cs
@@ -92,7 +92,7 @@ namespace jNet.RPC.Client
             }
         }
 
-        protected internal abstract void OnEventNotification(SocketMessage message);
+        protected internal abstract void OnEventNotification(string eventName, EventArgs eventArgs);
 
         protected void NotifyPropertyChanged(string propertyName)
         {
@@ -107,15 +107,15 @@ namespace jNet.RPC.Client
 
         protected internal T DeserializeEventArgs<T>(SocketMessage message) where T: EventArgs
         {
-            return _client?.Deserialize<T>(message);
+            return _client?.Deserialize(message) as T;
         }
 
-        internal void OnNotificationMessage(SocketMessage message)
+        internal void OnNotificationMessage(string eventName, EventArgs eventArgs)
         {
-            Logger.Trace("On NotificationMessage {0}", message);
-            if (message.MemberName == nameof(INotifyPropertyChanged.PropertyChanged))
+            Logger.Trace("On NotificationMessage {0}", eventName);
+            if (eventName == nameof(INotifyPropertyChanged.PropertyChanged))
             {
-                var eav = DeserializeEventArgs<PropertyChangedWithValueEventArgs>(message);
+                var eav = eventArgs as PropertyChangedWithValueEventArgs;
                 if (eav == null)
                     return;
                 var type = GetType();
@@ -138,7 +138,7 @@ namespace jNet.RPC.Client
                 }
                 NotifyPropertyChanged(eav.PropertyName);
             }
-            else OnEventNotification(message);
+            else OnEventNotification(eventName, eventArgs);
         }
 
         protected FieldInfo GetField(Type t, string fieldName)

--- a/jNet.RPC/Client/RemoteClient.cs
+++ b/jNet.RPC/Client/RemoteClient.cs
@@ -29,8 +29,7 @@ namespace jNet.RPC.Client
             try
             {
                 var queryMessage = new SocketMessage(SocketMessage.SocketMessageType.RootQuery, Guid.Empty, null, 0, null);
-                var response = SendAndGetResponse<T>(queryMessage);
-                return response;
+                return SendAndGetResponse<T>(queryMessage);
             }
             catch (Exception e)
             {

--- a/jNet.RPC/Server/ServerHost.cs
+++ b/jNet.RPC/Server/ServerHost.cs
@@ -85,7 +85,7 @@ namespace jNet.RPC.Server
                 {
                     listener.Stop();
                     List<ServerSession> serverSessionsCopy;
-                    lock (((IList) _clients).SyncRoot)
+                    lock (((IList)_clients).SyncRoot)
                         serverSessionsCopy = _clients.ToList();
                     serverSessionsCopy.ForEach(s => s.Dispose());
                 }
@@ -107,7 +107,7 @@ namespace jNet.RPC.Server
         private void ClientSessionDisconnected(object sender, EventArgs e)
         {
             var serverSession = sender as ServerSession ?? throw new ArgumentException(nameof(sender));
-            lock (((IList) _clients).SyncRoot)
+            lock (((IList)_clients).SyncRoot)
                 _clients.Remove(serverSession);
             serverSession.Disconnected -= ClientSessionDisconnected;
             serverSession.Dispose();
@@ -117,7 +117,7 @@ namespace jNet.RPC.Server
         {
             get
             {
-                lock (((IList) _clients).SyncRoot)
+                lock (((IList)_clients).SyncRoot)
                     return _clients.Count;
             }
         }

--- a/jNet.RPC/Server/ServerObjectBase.cs
+++ b/jNet.RPC/Server/ServerObjectBase.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Xml.Serialization;
 
 namespace jNet.RPC.Server
@@ -48,8 +47,5 @@ namespace jNet.RPC.Server
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-
     }
-
-
 }

--- a/jNet.RPC/Server/ServerSession.cs
+++ b/jNet.RPC/Server/ServerSession.cs
@@ -292,7 +292,7 @@ namespace jNet.RPC.Server
         {
             NotifyClient(e.Dto, e, nameof(INotifyPropertyChanged.PropertyChanged));
         }
-        
+
         private T Deserialize<T>(SocketMessage message)
         {
             using (var stream = message.GetValueStream())

--- a/jNet.RPC/SocketConnection.cs
+++ b/jNet.RPC/SocketConnection.cs
@@ -21,9 +21,12 @@ namespace jNet.RPC
     {
         private const int MessageQueueCapacity =
 #if DEBUG 
-            1000;
+            10000;
 #else
             100000;
+#endif
+#if DEBUG
+        private readonly Random _random = new Random();
 #endif
         private const int MaxMessageSize = 0x4000000; // 64 MB
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
@@ -183,6 +186,10 @@ namespace jNet.RPC
                 try
                 {
                     var serializedMessage = _sendQueue.Take(DisconnectTokenSource.Token);
+#if DEBUG
+                    // Simulate network latency
+                    Thread.Sleep(_random.Next(5));
+#endif
                     Client.Client.Send(serializedMessage);
                 }
                 catch (OperationCanceledException)
@@ -250,6 +257,10 @@ namespace jNet.RPC
                         var message = new SocketMessage(dataBuffer, messageSize);
                         if (message.MessageType != SocketMessage.SocketMessageType.EventNotification)
                             Logger.Trace("Message received: {0}", message);
+#if DEBUG
+                        // Simulate network latency
+                        Thread.Sleep(_random.Next(5));
+#endif
                         _receiveQueue.Add(message);
                         messageSize = 0;
                         dataIndex = 0;

--- a/jNet.RPC/jNet.RPC.csproj
+++ b/jNet.RPC/jNet.RPC.csproj
@@ -7,11 +7,7 @@
     <AssemblyTitle>jNet.RPC</AssemblyTitle>
     <Description>JSON .Net RPC library</Description>
     <Product>jNet.RPC</Product>
-    <Copyright>2024</Copyright>
-    <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
-    <RunAnalyzersDuringLiveAnalysis>True</RunAnalyzersDuringLiveAnalysis>
-    <AnalysisLevel>none</AnalysisLevel>
-    <EnableNETAnalyzers>False</EnableNETAnalyzers>
+    <Copyright>2025</Copyright>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Fixed issue when order of deserialization was changed because event notifications are handled in separate thread. Now deserialization of events occurs on the same thread as rest messages, preserving correct references to DTOs.